### PR TITLE
Добавил package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "deodar",
+  "version": "0.1.0",
+  "description": "Классическая двухпанельная рабочая среда (коммандер) для О.С. Линукс",
+  "main": "deodar.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exebook/deodar"
+  },
+  "keywords": [
+    "orthodox file manager"
+  ],
+  "author": "exebook",
+  "license": "Unlicense",
+  "bugs": {
+    "url": "https://github.com/exebook/deodar/issues"
+  },
+  "homepage": "https://github.com/exebook/deodar",
+  "dependencies": {
+    "vt": "~0.1.1"
+  }
+}


### PR DESCRIPTION
Предлагаю Вам добавить файл `package.json`.
Вы могли бы в дальнейшем существенно упростит установку программы
(в случае публикации в `npm`) до команды

``` sh
npm install deodar -g
```

В раздел зависимости был добавлен модуль [vt](https://www.npmjs.org/package/vt), который Вы [предлагаете брать](https://github.com/exebook/deodar/blob/master/%D1%83%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0.%D0%B1%D1%83%D0%BA%D0%B2) из [репозитория](https://github.com/c3ks/terminal.js).

Так же было бы очень удобно, если бы остальные используемые Вами модули были размещены в [npm](http://npmjs.org) тоже.
К сожалению, запустить приложение [у меня так и не вышло](https://github.com/exebook/glxwin/issues/1). Хотя очень интересно посмотреть, я тоже разрабатываю [ортодоксальный файловый менеджер](http://ru.cloudcmd.io) на `JavaScript/Node.js` только для веб, а не для консоли.
